### PR TITLE
Add support to create a new SinkRecord from key, value and header fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ![Actions Status](https://github.com/Landoop/kafka-connect-common/workflows/CI/badge.svg)
-[<img 
-src="https://img.shields.io/badge/latest%20release-v02.0.6-blue.svg?label=latest%20release"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.datamountaineer%22%20AND%20a%3A%22kafka-connect-common%22)
+[<img src="https://img.shields.io/badge/latest%20release-v02.0.6-blue.svg?label=latest%20release"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.datamountaineer%22%20AND%20a%3A%22kafka-connect-common%22)
 Kafka Connect Common is in Maven, include it in your connector.
 
 
@@ -9,6 +8,7 @@ Kafka Connect Common is in Maven, include it in your connector.
 
 | Version | Confluent Version |Kafka| Kcql Version | Scala Version |
 | ------- | ----------------- |-----|--------------|---------------|
+|2.0.6|5.4.0|2.4.0|2.8.8|2.12
 |2.0.5|5.4.0|2.4.0|2.8.8|2.12
 |2.0.5|5.4.0|2.4.0|2.8.7|2.12
 |2.0.4|5.4.0|2.4.0|2.8.7|2.12

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Actions Status](https://github.com/Landoop/kafka-connect-common/workflows/CI/badge.svg)
 [<img 
-src="https://img.shields.io/badge/latest%20release-v02.0.5-blue.svg?label=latest%20release"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.datamountaineer%22%20AND%20a%3A%22kafka-connect-common%22)
+src="https://img.shields.io/badge/latest%20release-v02.0.6-blue.svg?label=latest%20release"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.datamountaineer%22%20AND%20a%3A%22kafka-connect-common%22)
 Kafka Connect Common is in Maven, include it in your connector.
 
 
@@ -9,6 +9,7 @@ Kafka Connect Common is in Maven, include it in your connector.
 
 | Version | Confluent Version |Kafka| Kcql Version | Scala Version |
 | ------- | ----------------- |-----|--------------|---------------|
+|2.0.5|5.4.0|2.4.0|2.8.8|2.12
 |2.0.5|5.4.0|2.4.0|2.8.7|2.12
 |2.0.4|5.4.0|2.4.0|2.8.7|2.12
 |2.0.3|5.4.0|2.4.0|2.8.6|2.12

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ allprojects {
         avro4sVersion = "1.6.4"
         guavaVersion = "18.0"
         json4sVersion = "3.6.7"
-        kcqlVersion =  "2.8.7"
+        kcqlVersion =  "2.8.8"
         smt = "2.0.0"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.0.5
+version=2.0.6
 
 ossrhUsername=me
 ossrhPassword=you

--- a/src/main/java/com/datamountaineer/streamreactor/connect/json/SimpleJsonConverter.java
+++ b/src/main/java/com/datamountaineer/streamreactor/connect/json/SimpleJsonConverter.java
@@ -227,6 +227,7 @@ public class SimpleJsonConverter {
   }
 
 
+
   private interface JsonToConnectTypeConverter {
     Object convert(Schema schema, JsonNode value);
   }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/MsgKey.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/MsgKey.scala
@@ -26,5 +26,5 @@ object MsgKey {
   private val avroData = new AvroData(1)
   val schema = avroData.toConnectSchema(avroSchema)
 
-  def getStruct(topic: String, id: String) = avroData.toConnectData(avroSchema, recordFormat.to(MsgKey(topic, id))).value()
+  def getStruct(topic: String, id: String): AnyRef = avroData.toConnectData(avroSchema, recordFormat.to(MsgKey(topic, id))).value()
 }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/Transform.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/Transform.scala
@@ -78,7 +78,8 @@ object Transform extends StrictLogging {
           case Schema.Type.STRUCT =>
             val struct = value.asInstanceOf[Struct]
             Try(struct.sql(fields, !withStructure)) match {
-              case Success(s) => simpleJsonConverter.fromConnectData(s.schema(), s).toString
+              case Success(s) =>
+                simpleJsonConverter.fromConnectData(s.schema(), s).toString
 
               case Failure(e) => raiseException(s"A KCQL error occurred.${e.getMessage}", e)
             }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/Transform.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/Transform.scala
@@ -52,7 +52,7 @@ object Transform extends StrictLogging {
             val array = value match {
               case a: Array[Byte] => a
               case b: ByteBuffer => b.array()
-              case other => raiseException("Invalid payload:$other for schema Schema.BYTES.", null)
+              case other => raiseException(s"Invalid payload: [$other] for schema Schema.BYTES.", null)
             }
 
             Try(JacksonJson.mapper.readTree(array)) match {
@@ -71,7 +71,7 @@ object Transform extends StrictLogging {
               case Success(json) =>
                 Try(json.sql(fields, !withStructure)) match {
                   case Success(jn) => jn.toString
-                  case Failure(e) => raiseException(s"A KCQL exception occurred.${e.getMessage}", e)
+                  case Failure(e) => raiseException(s"A KCQL exception occurred. ${e.getMessage}", e)
                 }
             }
 
@@ -81,10 +81,10 @@ object Transform extends StrictLogging {
               case Success(s) =>
                 simpleJsonConverter.fromConnectData(s.schema(), s).toString
 
-              case Failure(e) => raiseException(s"A KCQL error occurred.${e.getMessage}", e)
+              case Failure(e) => raiseException(s"A KCQL error occurred. ${e.getMessage}", e)
             }
 
-          case other => raiseException("Can't transform Schema type:$other.", null)
+          case other => raiseException(s"Can't transform Schema type: [$other].", null)
         }
       } else {
         //we can handle java.util.Map (this is what JsonConverter can spit out)
@@ -94,7 +94,7 @@ object Transform extends StrictLogging {
             val jsonNode: JsonNode = JacksonJson.mapper.valueToTree(map)
             Try(jsonNode.sql(fields, !withStructure)) match {
               case Success(j) => j.toString
-              case Failure(e) => raiseException(s"A KCQL exception occurred.${e.getMessage}", e)
+              case Failure(e) => raiseException(s"A KCQL exception occurred. ${e.getMessage}", e)
             }
           case s: String =>
             Try(JacksonJson.asJson(value.asInstanceOf[String])) match {
@@ -102,7 +102,7 @@ object Transform extends StrictLogging {
               case Success(json) =>
                 Try(json.sql(fields, !withStructure)) match {
                   case Success(jn) => jn.toString
-                  case Failure(e) => raiseException(s"A KCQL exception occurred.${e.getMessage}", e)
+                  case Failure(e) => raiseException(s"A KCQL exception occurred. ${e.getMessage}", e)
                 }
             }
 
@@ -116,7 +116,7 @@ object Transform extends StrictLogging {
                 }
             }
           //we take it as String
-          case other => raiseException(s"Value:$other is not handled!", null)
+          case other => raiseException(s"Value: [$other] is not handled!", null)
         }
       }
     }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/sink/AvroConverter.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/sink/AvroConverter.scala
@@ -86,7 +86,7 @@ object AvroConverter {
   val SCHEMA_CONFIG = "connect.converter.avro.schemas"
 
   def getSchemas(config: Map[String, String]): Map[String, AvroSchema] = {
-    config.getOrElse(SCHEMA_CONFIG, throw new ConfigException(s"$SCHEMA_CONFIG is not provided"))
+    config.getOrElse(SCHEMA_CONFIG, throw new ConfigException(s"[$SCHEMA_CONFIG] is not provided"))
       .toString
       .split(';')
       .filter(_.trim.nonEmpty)
@@ -95,14 +95,14 @@ object AvroConverter {
         case Array(sink, path) =>
           val file = new File(path)
           if (!file.exists()) {
-            throw new ConfigException(s"Invalid $SCHEMA_CONFIG. The file $path doesn't exist!")
+            throw new ConfigException(s"Invalid [$SCHEMA_CONFIG]. The file [$path] doesn't exist!")
           }
           val s = sink.trim.toLowerCase()
           if (s.isEmpty) {
-            throw new ConfigException(s"Invalid $SCHEMA_CONFIG. The topic is not valid for entry containing $path")
+            throw new ConfigException(s"Invalid [$SCHEMA_CONFIG]. The topic is not valid for entry containing [$path]")
           }
           s -> new AvroSchema.Parser().parse(file)
-        case other => throw new ConfigException(s"$SCHEMA_CONFIG is not properly set. The format is Mqtt_Sink->AVRO_FILE")
+        case other => throw new ConfigException(s"[$SCHEMA_CONFIG] is not properly set. The format is Mqtt_Sink->AVRO_FILE")
       }.toMap
   }
 }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/sink/SinkRecordToJson.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/sink/SinkRecordToJson.scala
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package com.datamountaineer.streamreactor.connect.converters.source
+package com.datamountaineer.streamreactor.connect.converters.sink
 
 import com.datamountaineer.streamreactor.connect.schemas.ConverterUtil
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/AvroConverter.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/AvroConverter.scala
@@ -48,7 +48,7 @@ class AvroConverter extends Converter {
           avroData.toConnectSchema(sourceToSchemaMap(sourceTopic)),
           null)
       case Some(_) =>
-        val reader = avroReadersMap.getOrElse(sourceTopic.toLowerCase, throw new ConfigException(s"Invalid ${AvroConverter.SCHEMA_CONFIG} is not configured for $sourceTopic"))
+        val reader = avroReadersMap.getOrElse(sourceTopic.toLowerCase, throw new ConfigException(s"Invalid [${AvroConverter.SCHEMA_CONFIG}] is not configured for [$sourceTopic]"))
         val decoder = DecoderFactory.get().binaryDecoder(bytes, null)
         val record = reader.read(null, decoder)
         val schemaAndValue = avroData.toConnectData(sourceToSchemaMap(sourceTopic.toLowerCase), record)
@@ -92,7 +92,7 @@ object AvroConverter {
   val SCHEMA_CONFIG = "connect.source.converter.avro.schemas"
 
   def getSchemas(config: Map[String, String]): Map[String, AvroSchema] = {
-    config.getOrElse(SCHEMA_CONFIG, throw new ConfigException(s"$SCHEMA_CONFIG is not provided"))
+    config.getOrElse(SCHEMA_CONFIG, throw new ConfigException(s"[$SCHEMA_CONFIG] is not provided"))
       .toString
       .split(';')
       .filter(_.trim.nonEmpty)
@@ -101,14 +101,14 @@ object AvroConverter {
         case Array(source, path) =>
           val file = new File(path)
           if (!file.exists()) {
-            throw new ConfigException(s"Invalid $SCHEMA_CONFIG. The file $path doesn't exist!")
+            throw new ConfigException(s"Invalid [$SCHEMA_CONFIG]. The file [$path] doesn't exist!")
           }
           val s = source.trim.toLowerCase()
           if (s.isEmpty) {
-            throw new ConfigException(s"Invalid $SCHEMA_CONFIG. The topic is not valid for entry containing $path")
+            throw new ConfigException(s"Invalid [$SCHEMA_CONFIG]. The topic is not valid for entry containing [$path]")
           }
           s -> new AvroSchema.Parser().parse(file)
-        case other => throw new ConfigException(s"$SCHEMA_CONFIG is not properly set. The format is Mqtt_Source->AVRO_FILE")
+        case other => throw new ConfigException(s"[$SCHEMA_CONFIG] is not properly set. The format is Mqtt_Source->AVRO_FILE")
       }.toMap
   }
 }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/JsonOptNullConverter.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/JsonOptNullConverter.scala
@@ -33,7 +33,7 @@ class JsonOptNullConverter extends Converter {
                        keys:Seq[String] = Seq.empty,
                        keyDelimiter:String = ".",
                        properties: Map[String, String] = Map.empty): SourceRecord = {
-    require(bytes != null, s"Invalid $bytes parameter")
+    require(bytes != null, s"Invalid [$bytes] parameter")
     val json = new String(bytes, Charset.defaultCharset)
     val schemaAndValue = JsonOptNullConverter.convert(sourceTopic, json)
     val value = schemaAndValue.value()

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/JsonPassThroughConverter.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/JsonPassThroughConverter.scala
@@ -30,7 +30,7 @@ class JsonPassThroughConverter extends Converter {
                        keys: Seq[String] = Seq.empty,
                        keyDelimiter: String = ".",
                        properties: Map[String, String] = Map.empty): SourceRecord = {
-    require(bytes != null, s"Invalid $bytes parameter")
+    require(bytes != null, s"Invalid [$bytes] parameter")
 
     val json = new String(bytes, "utf-8")
     val jsonNode = JacksonJson.asJson(json)

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/JsonSimpleConverter.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/JsonSimpleConverter.scala
@@ -33,7 +33,7 @@ class JsonSimpleConverter extends Converter {
                        keys:Seq[String] = Seq.empty,
                        keyDelimiter:String = ".",
                        properties: Map[String, String] = Map.empty): SourceRecord = {
-    require(bytes != null, s"Invalid $bytes parameter")
+    require(bytes != null, s"Invalid [$bytes] parameter")
     val json = new String(bytes, Charset.defaultCharset)
     val schemaAndValue = JsonSimpleConverter.convert(sourceTopic, json)
     val value = schemaAndValue.value()

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/JsonSimpleConverter.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/JsonSimpleConverter.scala
@@ -80,15 +80,15 @@ object JsonSimpleConverter {
 
         val schema = SchemaBuilder.array(sv.schema()).optional().build()
         new SchemaAndValue(schema, values)
-      case JBool(b) => new SchemaAndValue(Schema.BOOLEAN_SCHEMA, b)
+      case JBool(b) => new SchemaAndValue(Schema.OPTIONAL_BOOLEAN_SCHEMA, b)
       case JDecimal(d) =>
         val schema = Decimal.builder(d.scale).optional().build()
         new SchemaAndValue(schema, Decimal.fromLogical(schema, d.bigDecimal))
-      case JDouble(d) => new SchemaAndValue(Schema.FLOAT64_SCHEMA, d)
-      case JInt(i) => new SchemaAndValue(Schema.INT64_SCHEMA, i.toLong) //on purpose! LONG (we might get later records with long entries)
-      case JLong(l) => new SchemaAndValue(Schema.INT64_SCHEMA, l)
-      case JNull | JNothing => new SchemaAndValue(Schema.STRING_SCHEMA, null)
-      case JString(s) => new SchemaAndValue(Schema.STRING_SCHEMA, s)
+      case JDouble(d) => new SchemaAndValue(Schema.OPTIONAL_FLOAT64_SCHEMA, d)
+      case JInt(i) => new SchemaAndValue(Schema.OPTIONAL_INT64_SCHEMA, i.toLong) //on purpose! LONG (we might get later records with long entries)
+      case JLong(l) => new SchemaAndValue(Schema.OPTIONAL_INT64_SCHEMA, l)
+      case JNull | JNothing => new SchemaAndValue(Schema.OPTIONAL_STRING_SCHEMA, null)
+      case JString(s) => new SchemaAndValue(Schema.OPTIONAL_STRING_SCHEMA, s)
       case JObject(values) =>
         val builder = SchemaBuilder.struct().name(name.replace("/", "_"))
 

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/KeyExtractor.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/converters/source/KeyExtractor.scala
@@ -13,7 +13,7 @@ object KeyExtractor {
     def innerExtract(n: JsonNode, p: Vector[String]): Any = {
       def checkValidPath() = {
         if (p.nonEmpty) {
-          throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. It doesn't resolve to a primitive field")
+          throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. It doesn't resolve to a primitive field")
         }
       }
 
@@ -60,18 +60,18 @@ object KeyExtractor {
 
         case node: ObjectNode =>
           if (p.isEmpty) {
-            throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. The path is not resolving to a primitive field")
+            throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. The path is not resolving to a primitive field")
           }
           val childNode = Option(node.get(p.head)).getOrElse {
-            throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. Can't find ${p.head} field. Field found are:${node.fieldNames().asScala.mkString(",")}")
+            throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. Can't find ${p.head} field. Field found are:${node.fieldNames().asScala.mkString(",")}")
           }
 
           innerExtract(childNode, p.tail)
         case array: ArrayNode =>
-          throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. The path is involving an array structure")
+          throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. The path is involving an array structure")
 
         case other =>
-          throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. $other is not handled")
+          throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. $other is not handled")
       }
     }
 
@@ -87,13 +87,13 @@ object KeyExtractor {
     def innerExtract(field: Field, value: AnyRef, p: Vector[String]): Any = {
       def checkValidPath() = {
         if (p.nonEmpty) {
-          throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. It doesn't resolve to a primitive field")
+          throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. It doesn't resolve to a primitive field")
         }
       }
 
 
       if (value == null) {
-        throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. Field '${field.name()}' is null")
+        throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. Field [${field.name()}] is null")
       }
       Option(field.schema().name()).collect {
         case Decimal.LOGICAL_NAME =>
@@ -113,7 +113,7 @@ object KeyExtractor {
             case i: Int =>
               checkValidPath()
               Date.toLogical(field.schema, i)
-            case _ => throw new IllegalArgumentException(s"Can't convert $value to Date for schema:${field.schema().`type`()}")
+            case _ => throw new IllegalArgumentException(s"Can't convert [$value] to Date for schema: [${field.schema().`type`()}]")
           }
         case Time.LOGICAL_NAME =>
           value.asInstanceOf[Any] match {
@@ -123,7 +123,7 @@ object KeyExtractor {
             case d: java.util.Date =>
               checkValidPath()
               d
-            case _ => throw new IllegalArgumentException(s"Can't convert $value to Date for schema:${field.schema().`type`()}")
+            case _ => throw new IllegalArgumentException(s"Can't convert [$value] to Date for schema: [${field.schema().`type`()}]")
           }
         case Timestamp.LOGICAL_NAME =>
           value.asInstanceOf[Any] match {
@@ -133,7 +133,7 @@ object KeyExtractor {
             case d: java.util.Date =>
               checkValidPath()
               d
-            case _ => throw new IllegalArgumentException(s"Can't convert $value to Date for schema:${field.schema().`type`()}")
+            case _ => throw new IllegalArgumentException(s"Can't convert [$value] to Date for schema: [${field.schema().`type`()}]")
           }
       }.getOrElse {
         val v = field.schema().`type`() match {
@@ -167,7 +167,7 @@ object KeyExtractor {
 
           case Schema.Type.MAP =>
             if (p.isEmpty) {
-              throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. It doesn't resolve to a primitive field. It resolves to:${field.schema()}")
+              throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. It doesn't resolve to a primitive field. It resolves to: [${field.schema()}]")
             }
             val map = value.asInstanceOf[java.util.Map[String, AnyRef]]
             val f = new Field(p.head, 0, field.schema().valueSchema())
@@ -176,12 +176,12 @@ object KeyExtractor {
 
           case Schema.Type.STRUCT =>
             if (p.isEmpty) {
-              throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. It doesn't resolve to a primitive field. It resolves to:${field.schema()}")
+              throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. It doesn't resolve to a primitive field. It resolves to: [${field.schema()}]")
             }
             val s = value.asInstanceOf[Struct]
             val childField = Option(s.schema().field(p.head))
               .getOrElse {
-                throw new IllegalArgumentException(s"Invalid field selection for '${path.mkString(".")}'. Can't find field '${p.head}'. Fields available:${s.schema().fields().asScala.map(_.name()).mkString(",")}")
+                throw new IllegalArgumentException(s"Invalid field selection for [${path.mkString(".")}]. Can't find field [${p.head}]. Fields available: [${s.schema().fields().asScala.map(_.name()).mkString(",")}]")
               }
 
             innerExtract(childField, s.get(childField), p.tail)
@@ -192,7 +192,7 @@ object KeyExtractor {
     }
 
     val field = Option(struct.schema().field(path.head)).getOrElse {
-      throw new IllegalArgumentException(s"Couldn't find field '${path.head}' in the schema:${struct.schema().fields().asScala.map(_.name()).mkString(",")}")
+      throw new IllegalArgumentException(s"Couldn't find field [${path.head}] in the schema: [${struct.schema().fields().asScala.map(_.name()).mkString(",")}]")
     }
 
     innerExtract(field, struct.get(field), path.tail)

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/errors/ErrorHandler.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/errors/ErrorHandler.scala
@@ -50,7 +50,7 @@ trait ErrorHandler extends StrictLogging {
       case Success(s) => {
         //success, check if we had previous errors.
         if (errorTracker.get.retries != errorTracker.get.maxRetries) {
-          logger.info(s"Recovered from error ${errorTracker.get.lastErrorMessage} at " +
+          logger.info(s"Recovered from error [${errorTracker.get.lastErrorMessage}] at " +
             s"${dateFormatter.format(errorTracker.get.lastErrorTimestamp)}")
         }
         //cleared error
@@ -59,7 +59,7 @@ trait ErrorHandler extends StrictLogging {
       }
       case Failure(f) =>
         //decrement the retry count
-        logger.error(s"Encountered error ${f.getMessage}", f)
+        logger.error(s"Encountered error [${f.getMessage}]", f)
         this.errorTracker = Some(decrementErrorTracker(errorTracker.get, f.getMessage))
         handleError(f, errorTracker.get.retries, errorTracker.get.policy)
         None

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/errors/ErrorPolicy.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/errors/ErrorPolicy.scala
@@ -49,7 +49,7 @@ object ErrorPolicy extends StrictLogging {
 
 case class NoopErrorPolicy() extends ErrorPolicy {
   override def handle(error: Throwable, sink: Boolean = true, retryCount: Int = 0){
-    logger.warn(s"Error policy NOOP: ${error.getMessage}. Processing continuing.")
+    logger.warn(s"Error policy NOOP: [${error.getMessage}]. Processing continuing.")
   }
 }
 
@@ -66,7 +66,7 @@ case class RetryErrorPolicy() extends ErrorPolicy {
       throw new RuntimeException(error)
     }
     else {
-      logger.warn(s"Error policy set to RETRY. Remaining attempts $retryCount")
+      logger.warn(s"Error policy set to RETRY. Remaining attempts [$retryCount]")
       throw new RetriableException(error)
     }
   }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/queues/QueueHelpers.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/queues/QueueHelpers.scala
@@ -64,7 +64,7 @@ object QueueHelpers extends StrictLogging {
     * */
   def drainQueueWithTimeOut[T](queue: LinkedBlockingQueue[T], batchSize: Int, timeOut: Long) = {
     val l = new util.ArrayList[T]()
-    logger.debug(s"Found ${queue.size()}. Draining entries to batchSize ${batchSize}.")
+    logger.debug(s"Found [${queue.size()}]. Draining entries to batchSize [${batchSize}].")
     queue.drainWithTimeoutTo(l, batchSize, timeOut, TimeUnit.MILLISECONDS)
     l
   }
@@ -78,7 +78,7 @@ object QueueHelpers extends StrictLogging {
     * */
   def drainQueue[T](queue: LinkedBlockingQueue[T], batchSize: Int) = {
     val l = new util.ArrayList[T]()
-    logger.debug(s"Found ${queue.size()}. Draining entries to batchSize ${batchSize}.")
+    logger.debug(s"Found ${queue.size()}. Draining entries to batchSize [${batchSize}].")
     queue.drainTo(l, batchSize)
     l
   }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/rowkeys/RowKeyBuilderString.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/rowkeys/RowKeyBuilderString.scala
@@ -90,13 +90,13 @@ case class StringStructFieldsStringKeyBuilder(keys: Seq[String],
 
     val availableFields = schema.fields().asScala.map(_.name).toSet
     val missingKeys = keys.filterNot(availableFields.contains)
-    require(missingKeys.isEmpty, s"${missingKeys.mkString(",")} keys are not present in the SinkRecord payload:${availableFields.mkString(",")}")
+    require(missingKeys.isEmpty, s"[${missingKeys.mkString(",")}] keys are not present in the SinkRecord payload: [${availableFields.mkString(",")}]")
 
     keys.flatMap { case key =>
       val field = schema.field(key)
       val value = struct.get(field)
 
-      require(value != null, s"$key field value is null. Non null value is required for the fileds creating the Hbase row key")
+      require(value != null, s"[$key] field value is null. Non null value is required for the fields creating the Hbase row key")
       if (availableSchemaTypes.contains(field.schema().`type`())) Some(value.toString)
       else None
     }.mkString(keyDelimiter)

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/ConverterUtil.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/ConverterUtil.scala
@@ -141,7 +141,7 @@ trait ConverterUtil {
 
     val schema = if (key) record.keySchema() else record.valueSchema()
     val expectedInput = schema != null && schema.`type`() == Schema.STRING_SCHEMA.`type`()
-    if (!expectedInput) Left(s"$schema is not handled. Expecting Schema.String")
+    if (!expectedInput) Left(s"[$schema] is not handled. Expecting Schema.String")
     else {
       (if (key) record.key() else record.value()) match {
         case s: String =>
@@ -174,7 +174,7 @@ trait ConverterUtil {
                   }
                 }
               Right(ConversionResult(json, converted))
-            case Failure(_) => Left(s"Invalid json with the record on topic ${record.topic} and offset ${record.kafkaOffset()}")
+            case Failure(_) => Left(s"Invalid json with the record on topic [${record.topic}], partition [${record.kafkaPartition()}] and offset [${record.kafkaOffset()}]")
           }
         case other => Left(s"${other.getClass} is not valid. Expecting a Struct")
       }
@@ -225,7 +225,7 @@ trait ConverterUtil {
 
         case other =>
           new ConnectException(
-            s"${other.getClass} is not valid. Expecting a Struct.")
+            s"[${other.getClass}] is not valid. Expecting a Struct.")
           record
       }
     }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/PayloadFields.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/PayloadFields.scala
@@ -45,7 +45,7 @@ object PayloadFields {
               field -> field
             case Seq(field, alias) =>
               field -> alias
-            case _ => throw new ConfigException(s"$c is not valid. Need to set the fields and mappings like: field1,field2,field3=alias3,[field4, field5=alias5]")
+            case _ => throw new ConfigException(s"[$c] is not valid. Need to set the fields and mappings like: field1,field2,field3=alias3,[field4, field5=alias5]")
           }
         }.toMap
 

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/SinkRecordConverterHelper.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/SinkRecordConverterHelper.scala
@@ -1,0 +1,186 @@
+package com.datamountaineer.streamreactor.connect.schemas
+
+import java.util
+
+import com.datamountaineer.streamreactor.connect.converters.sink.SinkRecordToJson.{convertSchemalessJson, convertStringSchemaAndJson}
+import com.datamountaineer.streamreactor.connect.schemas.StructHelper.StructExtension
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
+import org.apache.kafka.connect.errors.ConnectException
+import org.apache.kafka.connect.header.ConnectHeaders
+import org.apache.kafka.connect.sink.SinkRecord
+import org.json4s.JsonAST.JObject
+
+import scala.collection.JavaConverters._
+
+object SinkRecordConverterHelper extends StrictLogging {
+
+  implicit final class SinkRecordExtension(val record: SinkRecord)
+      extends AnyVal {
+
+    private def structFromHeaders(headerFields: Map[String, String]): Struct = {
+
+      val extractHeaderFields =
+        if (headerFields.nonEmpty && headerFields.contains("*")) {
+          record
+            .headers()
+            .asScala
+            .filter(h => h.schema().`type`() == Schema.STRING_SCHEMA.`type`())
+            .map(h => (h.key() -> h.key()))
+            .toMap
+        } else {
+          headerFields
+        }
+
+      val schemaBuilder = SchemaBuilder.struct()
+
+      val headers =
+        record
+          .headers()
+          .iterator()
+          .asScala
+          // only take string headers and those in our list of fields
+          .filter(h =>
+            h.schema().`type`() == Schema.STRING_SCHEMA
+              .`type`() && extractHeaderFields.contains(h.key()))
+          //get the alias
+          .map(h => (extractHeaderFields(h.key()), h.value()))
+          .map {
+            case (name, value) =>
+              schemaBuilder.field(name, Schema.STRING_SCHEMA)
+              (name, value)
+          }
+          .toMap
+
+      val newStruct = new Struct(schemaBuilder.build())
+      headers.foreach { case (name, value) => newStruct.put(name, value) }
+      newStruct
+    }
+
+
+    /**
+     * make new sink record, taking fields
+     * from the key, value and headers
+     * */
+    def newFilteredRecord(
+        fields: Map[String, String],
+        ignoreFields: Set[String] = Set.empty[String],
+        keyFields: Map[String, String] = Map.empty[String, String],
+        headerFields: Map[String, String] = Map.empty[String, String],
+        retainKey: Boolean = false,
+        retainHeaders: Boolean = false): SinkRecord = {
+
+      //if we have keys fields and a key value extract
+      val keyStruct = if (keyFields.nonEmpty && record.key() != null) {
+        extract(payload = record.key(),
+                payloadSchema = record.keySchema(),
+                key = true,
+                fields = keyFields,
+                ignoreFields = Set.empty)
+      } else {
+        logger.warn(
+          s"Key is null for topic [${record.topic()}], partition [${record
+            .kafkaPartition()}], offset [${record.kafkaOffset()}])")
+        new Struct(SchemaBuilder.struct().build())
+      }
+
+      //if we have value fields and a value extract
+      val valueStruct = if (fields.nonEmpty && record.value() != null) {
+        extract(payload = record.value(),
+                payloadSchema = record.valueSchema(),
+                key = false,
+                fields = fields,
+                ignoreFields = ignoreFields)
+      } else {
+        logger.warn(
+          s"Value is null for topic [${record.topic()}], partition [${record
+            .kafkaPartition()}], offset [${record.kafkaOffset()}])")
+        new Struct(SchemaBuilder.struct().build())
+      }
+
+      //create a new struct with the keys, values and headers
+      val struct = keyStruct ++ valueStruct ++ structFromHeaders(headerFields)
+
+      new SinkRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        if (retainKey) record.keySchema() else null,
+        if (retainKey) record.key() else null,
+        struct.schema(),
+        struct,
+        record.kafkaOffset(),
+        record.timestamp(),
+        record.timestampType(),
+        if (retainHeaders) record.headers() else new ConnectHeaders()
+      )
+    }
+
+    private def extract(payload: Object,
+                        payloadSchema: Schema,
+                        key: Boolean,
+                        fields: Map[String, String],
+                        ignoreFields: Set[String]): Struct = {
+
+      if (payloadSchema == null) {
+        //json with no schema
+        val j: util.Map[String, Any] = convertSchemalessJson(
+          record = record,
+          fields = fields,
+          ignoreFields = ignoreFields,
+          key = key,
+          includeAllFields = fields.contains("*")
+        )
+
+        val newSchema = SchemaBuilder.struct()
+        j.asScala
+          .foreach {
+            case (name, value) => newSchema.field(name, Schema.STRING_SCHEMA)
+          }
+
+        val newStruct = new Struct(newSchema.build())
+        j.asScala.foreach {
+          case (name, value) => newStruct.put(name, value.toString)
+        }
+        newStruct
+
+      } else {
+        payloadSchema.`type`() match {
+          //struct
+          case Schema.Type.STRUCT =>
+            payload
+              .asInstanceOf[Struct]
+              .reduceToSchema(schema = payloadSchema,
+                              fields = fields,
+                              ignoreFields = ignoreFields)
+
+          // json with string schema
+          case Schema.Type.STRING =>
+            val j = convertStringSchemaAndJson(record = record,
+                                               fields = fields,
+                                               ignoreFields = ignoreFields,
+                                               key = key,
+                                               includeAllFields =
+                                                 fields.contains("*"))
+
+            val newSchema = SchemaBuilder.struct()
+            val jFields = j.asInstanceOf[JObject].values
+            jFields.foreach {
+              case (name, value) =>
+                // default to string
+                newSchema.field(name, Schema.STRING_SCHEMA)
+            }
+            val newStruct = new Struct(newSchema.build())
+            jFields.foreach {
+              case (name, value) =>
+                newStruct.put(name, value.toString)
+            }
+            newStruct
+
+          case other =>
+            throw new ConnectException(
+              s"$other schema is not supported for extracting fields")
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/SinkRecordConverterHelper.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/SinkRecordConverterHelper.scala
@@ -1,25 +1,15 @@
 package com.datamountaineer.streamreactor.connect.schemas
 
-import com.datamountaineer.streamreactor.connect.converters.sink.SinkRecordToJson.{
-  connectSchemaTypeToSchema,
-  convertFromStringAsJson
-}
 import com.datamountaineer.streamreactor.connect.converters.source.JsonSimpleConverter
 import com.datamountaineer.streamreactor.connect.schemas.StructHelper.StructExtension
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.typesafe.scalalogging.StrictLogging
-import org.apache.kafka.connect.data.{
-  ConnectSchema,
-  Schema,
-  SchemaBuilder,
-  Struct
-}
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.header.ConnectHeaders
 import org.apache.kafka.connect.sink.SinkRecord
 
 import scala.collection.JavaConverters._
-import scala.collection.convert.ImplicitConversions.`map AsScala`
 import scala.util.{Failure, Success, Try}
 
 object SinkRecordConverterHelper extends StrictLogging {

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/StructHelper.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/StructHelper.scala
@@ -1,7 +1,7 @@
 package com.datamountaineer.streamreactor.connect.schemas
 
 import com.datamountaineer.streamreactor.connect.schemas.SchemaHelper.SchemaExtensions
-import com.typesafe.scalalogging.{Logger, StrictLogging}
+import com.typesafe.scalalogging.Logger
 import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/StructHelper.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/schemas/StructHelper.scala
@@ -81,6 +81,7 @@ object StructHelper {
       output
     }
 
+    // Reduce a schema to the fields specified
     def reduceSchema(schema: Schema,
                      fields: Map[String, String],
                      ignoreFields: Set[String]): Struct = {

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/serialization/AvroSerializer.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/serialization/AvroSerializer.scala
@@ -26,7 +26,7 @@ import org.apache.avro.io.{DecoderFactory, EncoderFactory}
 object AvroSerializer {
   def write[T <: Product](t: T)(implicit os: OutputStream, formatter: RecordFormat[T], schemaFor: SchemaFor[T]): Unit = write(apply(t), schemaFor())
 
-  def write(record: GenericRecord, schema: Schema)(implicit os: OutputStream) = {
+  def write(record: GenericRecord, schema: Schema)(implicit os: OutputStream): Unit = {
     val writer = new GenericDatumWriter[GenericRecord](schema)
     val encoder = EncoderFactory.get().binaryEncoder(os, null)
 

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/source/ExponentialBackOffHandler.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/source/ExponentialBackOffHandler.scala
@@ -27,14 +27,14 @@ import com.typesafe.scalalogging.StrictLogging
 class ExponentialBackOffHandler(name: String, step: Duration, cap: Duration) extends StrictLogging  {
   private var backoff = new ExponentialBackOff(step, cap)
 
-  def ready = backoff.passed
+  def ready: Boolean = backoff.passed
 
-  def failure = {
+  def failure: Unit = {
     backoff = backoff.nextFailure
     logger.info(s"$name: Next poll will be around ${backoff.endTime}")
   }
 
-  def success = {
+  def success: Unit = {
     backoff = backoff.nextSuccess
     logger.info(s"$name: Backing off. Next poll will be around ${backoff.endTime}")
   }
@@ -47,5 +47,5 @@ class ExponentialBackOffHandler(name: String, step: Duration, cap: Duration) ext
     }
   }
 
-  def remaining = backoff.remaining
+  def remaining: Duration = backoff.remaining
 }

--- a/src/main/scala/com/datamountaineer/streamreactor/connect/utils/ProgressCounter.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/utils/ProgressCounter.scala
@@ -40,7 +40,7 @@ case class ProgressCounter(periodMillis: Int = 60000) extends StrictLogging {
     records.foreach(r => counter.put(r.topic(), counter.getOrElse(r.topic(), 0L) + 1L))
 
     if ((newTimestamp - timestamp) >= periodMillis && records.nonEmpty) {
-      counter.foreach({ case (k, v) => logger.info(s"Delivered $v records for $k since $startTime") })
+      counter.foreach({ case (k, v) => logger.info(s"Delivered [$v] records for [$k] since $startTime") })
       counter.empty
       timestamp = newTimestamp
     }

--- a/src/test/scala/com/datamountaineer/streamreactor/connect/schemas/TestConverterUtil.scala
+++ b/src/test/scala/com/datamountaineer/streamreactor/connect/schemas/TestConverterUtil.scala
@@ -16,7 +16,6 @@
 
 package com.datamountaineer.streamreactor.connect.schemas
 
-import java.util
 import com.datamountaineer.streamreactor.connect.TestUtilsBase
 import com.datamountaineer.streamreactor.connect.schemas.SinkRecordConverterHelper.SinkRecordExtension
 import io.confluent.connect.avro.AvroData
@@ -24,8 +23,8 @@ import org.apache.kafka.connect.data.{Schema, Struct}
 import org.apache.kafka.connect.header.ConnectHeaders
 import org.apache.kafka.connect.json.JsonConverter
 import org.apache.kafka.connect.sink.SinkRecord
-import org.json4s.jackson.JsonMethods._
 
+import java.util
 import scala.collection.JavaConverters._
 
 /**
@@ -59,8 +58,10 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
 
     "return a subset SinkRecord" in {
       val testRecord = getTestRecord
-      val converted = convert(testRecord, Map("id" -> "id", "int_field" -> "int_field"))
-      val fields = converted.valueSchema().fields().asScala.map(f => f.name()).toSet
+      val converted =
+        convert(testRecord, Map("id" -> "id", "int_field" -> "int_field"))
+      val fields =
+        converted.valueSchema().fields().asScala.map(f => f.name()).toSet
       fields.contains("id") shouldBe true
       fields.contains("int_field") shouldBe true
       fields.contains("long_field") shouldBe false
@@ -69,10 +70,17 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
     "handle nested fields" in {
       val avroData = new AvroData(1)
       val avro = buildNestedAvro()
-      val testRecord= avroData.toConnectData(avro.getSchema, avro)
-      val input = new SinkRecord(TOPIC, 1, Schema.STRING_SCHEMA, KEY, testRecord.schema(), testRecord.value(), 1)
+      val testRecord = avroData.toConnectData(avro.getSchema, avro)
+      val input = new SinkRecord(TOPIC,
+                                 1,
+                                 Schema.STRING_SCHEMA,
+                                 KEY,
+                                 testRecord.schema(),
+                                 testRecord.value(),
+                                 1)
       val converted = convert(input, Map("x" -> "x", "y.a" -> "a"))
-      val fields = converted.valueSchema().fields().asScala.map(f => f.name()).toSet
+      val fields =
+        converted.valueSchema().fields().asScala.map(f => f.name()).toSet
       fields.contains("x") shouldBe true
       fields.contains("a") shouldBe true
       fields.contains("long_field") shouldBe false
@@ -82,23 +90,27 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
 
     "return a ignore fields SinkRecord" in {
       val testRecord = getTestRecord
-      val converted = convert(testRecord, Map.empty[String, String], Set("long_field"))
-      val fields = converted.valueSchema().fields().asScala.map(f => f.name()).toSet
+      val converted =
+        convert(testRecord, Map.empty[String, String], Set("long_field"))
+      val fields =
+        converted.valueSchema().fields().asScala.map(f => f.name()).toSet
       fields.contains("long_field") shouldBe false
     }
 
     "return same SinkRecord" in {
       val testRecord = getTestRecord
-      val converted = convert(testRecord, Map.empty[String, String], Set.empty[String])
+      val converted =
+        convert(testRecord, Map.empty[String, String], Set.empty[String])
       converted shouldBe testRecord
     }
 
     "throw an error while converting schemaless record if the payload is not Map[String, Any]" in {
       intercept[RuntimeException] {
-        val record = new SinkRecord("t", 0, null, null, null, "Should not be here", 0)
+        val record =
+          new SinkRecord("t", 0, null, null, null, "Should not be here", 0)
         record.newFilteredRecord(
           fields = Map("*" -> "*"),
-          ignoreFields =  Set.empty,
+          ignoreFields = Set.empty,
           keyFields = Map.empty,
           headerFields = Map.empty,
           retainKey = false,
@@ -116,7 +128,7 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       val record = new SinkRecord("t", 0, null, null, null, map, 0)
       val combinedRecord = record.newFilteredRecord(
         fields = Map("*" -> "*"),
-        ignoreFields =  Set("toremove"),
+        ignoreFields = Set("toremove"),
         keyFields = Map.empty,
         headerFields = Map.empty,
         retainKey = false,
@@ -124,9 +136,10 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       )
 
       val expected = "{\"field1\":\"value1\",\"field2\":3}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
-
 
     "only select the fields specified when converting a schemaless sink with the value being a json" in {
       val map = new util.HashMap[String, Any]()
@@ -137,7 +150,7 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
 
       val combinedRecord = record.newFilteredRecord(
         fields = Map("field1" -> "field1", "field2" -> "fieldRenamed"),
-        ignoreFields =  Set.empty,
+        ignoreFields = Set.empty,
         keyFields = Map.empty,
         headerFields = Map.empty,
         retainKey = false,
@@ -145,9 +158,10 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       )
 
       val expected = "{\"field1\":\"value1\",\"fieldRenamed\":3}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
-
 
     "rename the specified field when converting a schemaless record" in {
       val map = new util.HashMap[String, Any]()
@@ -157,23 +171,29 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       val record = new SinkRecord("t", 0, null, null, null, map, 0)
 
       val combinedRecord = record.newFilteredRecord(
-        fields = Map("field1" -> "field1", "field2" -> "fieldRenamed", "field3" -> "field3"),
-        ignoreFields =  Set("toremove"),
+        fields = Map("field1" -> "field1",
+                     "field2" -> "fieldRenamed",
+                     "field3" -> "field3"),
+        ignoreFields = Set("toremove"),
         keyFields = Map.empty,
         headerFields = Map.empty,
         retainKey = false,
         retainHeaders = false
       )
 
-      val expected = "{\"field1\":\"value1\",\"fieldRenamed\":3,\"field3\":null}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      val expected =
+        "{\"field1\":\"value1\",\"fieldRenamed\":3,\"field3\":null}"
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
 
     "convert a json via JsonConverter and then apply a field alias and one remove " in {
       val converter = new JsonConverter()
       converter.configure(Map("schemas.enable" -> false).asJava, false)
 
-      val schemaAndValue = converter.toConnectData("topicA",
+      val schemaAndValue = converter.toConnectData(
+        "topicA",
         """
           |{
           |    "id": 1,
@@ -181,15 +201,21 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
           |    "price": 12.50,
           |    "tags": ["home", "green"]
           |}
-        """.stripMargin.getBytes)
+        """.stripMargin.getBytes
+      )
 
-      val map = schemaAndValue.value().asInstanceOf[java.util.Map[String, Any]].asScala
-      map shouldBe Map("id" -> 1, "name" -> "A green door", "price" -> 12.5, "tags" -> List("home", "green").asJava)
+      val map =
+        schemaAndValue.value().asInstanceOf[java.util.Map[String, Any]].asScala
+      map shouldBe Map("id" -> 1,
+                       "name" -> "A green door",
+                       "price" -> 12.5,
+                       "tags" -> List("home", "green").asJava)
 
-      val record = new SinkRecord("topicA", 0, null, null, null, schemaAndValue.value, 0)
+      val record =
+        new SinkRecord("topicA", 0, null, null, null, schemaAndValue.value, 0)
       val combinedRecord = record.newFilteredRecord(
         fields = Map("id" -> "id", "tags" -> "tagsRenamed"),
-        ignoreFields =  Set("price"),
+        ignoreFields = Set("price"),
         keyFields = Map.empty,
         headerFields = Map.empty,
         retainKey = false,
@@ -197,16 +223,18 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       )
 
       val expected = "{\"id\":1,\"tagsRenamed\":[\"home\",\"green\"]}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
-
 
     "throw an error while converting a json payload" in {
       intercept[RuntimeException] {
-        val record = new SinkRecord("t", 0, null, null, null, Map.empty[String, String], 0)
+        val record =
+          new SinkRecord("t", 0, null, null, null, Map.empty[String, String], 0)
         record.newFilteredRecord(
           fields = Map("id" -> "id", "tags" -> "tagsRenamed"),
-          ignoreFields =  Set("price"),
+          ignoreFields = Set("price"),
           keyFields = Map.empty,
           headerFields = Map.empty,
           retainKey = false,
@@ -226,11 +254,12 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
           |}
         """.stripMargin
 
-      val record = new SinkRecord("t", 0, null, null, Schema.STRING_SCHEMA, json, 0)
+      val record =
+        new SinkRecord("t", 0, null, null, Schema.STRING_SCHEMA, json, 0)
 
       val combinedRecord = record.newFilteredRecord(
         fields = Map("*" -> "*"),
-        ignoreFields =  Set("toremove"),
+        ignoreFields = Set("toremove"),
         keyFields = Map.empty,
         headerFields = Map.empty,
         retainKey = false,
@@ -238,9 +267,10 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       )
 
       val expected = "{\"field1\":\"value1\",\"field2\":3}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
-
 
     "only select the fields specified when converting a record with Schema.String and payload a json string" in {
       val json =
@@ -252,7 +282,8 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
           |}
         """.stripMargin
 
-      val record = new SinkRecord("t", 0, null, null, Schema.STRING_SCHEMA, json, 0)
+      val record =
+        new SinkRecord("t", 0, null, null, Schema.STRING_SCHEMA, json, 0)
 
       val combinedRecord = record.newFilteredRecord(
         fields = Map("field1" -> "field1", "field2" -> "fieldRenamed"),
@@ -263,10 +294,11 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         retainHeaders = false
       )
 
-      val expected ="{\"field1\":\"value1\",\"fieldRenamed\":3}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      val expected = "{\"field1\":\"value1\",\"fieldRenamed\":3}"
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
-
 
     "rename the specified field when converting a record with Schema.String and value is json" in {
       val json =
@@ -278,7 +310,8 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
           |}
         """.stripMargin
 
-      val record = new SinkRecord("t", 0, null, null, Schema.STRING_SCHEMA, json, 0)
+      val record =
+        new SinkRecord("t", 0, null, null, Schema.STRING_SCHEMA, json, 0)
 
       val combinedRecord = record.newFilteredRecord(
         fields = Map("field1" -> "field1", "field2" -> "fieldRenamed"),
@@ -289,8 +322,10 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         retainHeaders = false
       )
 
-      val expected ="{\"field1\":\"value1\",\"fieldRenamed\":3}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      val expected = "{\"field1\":\"value1\",\"fieldRenamed\":3}"
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
 
     "apply a field alias and one remove when converting a sink record with Schema.String and the payload a json" in {
@@ -304,7 +339,8 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
           |}
         """.stripMargin
 
-      val record = new SinkRecord("topicA", 0, null, null, Schema.STRING_SCHEMA, json, 0)
+      val record =
+        new SinkRecord("topicA", 0, null, null, Schema.STRING_SCHEMA, json, 0)
       val combinedRecord = record.newFilteredRecord(
         fields = Map("id" -> "id", "tags" -> "tagsRenamed"),
         ignoreFields = Set("price"),
@@ -314,13 +350,16 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         retainHeaders = false
       )
 
-      val expected ="{\"id\":1,\"tagsRenamed\":[\"home\",\"green\"]}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      val expected = "{\"id\":1,\"tagsRenamed\":[\"home\",\"green\"]}"
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
 
     "add key fields and headers to record for Struct" in {
       val originalRecord = sinkRecordWithKeyHeaders()
-      val expected = "{\"key_int_field\":1,\"int_field\":1,\"header_alias_field_3\":\"boo\"}"
+      val expected =
+        "{\"key_int_field\":1,\"int_field\":1,\"header_alias_field_3\":\"boo\"}"
 
       val combinedRecord = originalRecord.newFilteredRecord(
         fields = Map("int_field" -> "int_field"),
@@ -329,11 +368,21 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         headerFields = Map("header_field_3" -> "header_alias_field_3")
       )
 
-      combinedRecord.valueSchema().fields().asScala.count(_.name().equals("key_int_field")) shouldBe 1
-      combinedRecord.valueSchema().fields().asScala.count(_.name().equals("header_alias_field_3")) shouldBe 1
+      combinedRecord
+        .valueSchema()
+        .fields()
+        .asScala
+        .count(_.name().equals("key_int_field")) shouldBe 1
+      combinedRecord
+        .valueSchema()
+        .fields()
+        .asScala
+        .count(_.name().equals("header_alias_field_3")) shouldBe 1
       combinedRecord.valueSchema().fields().asScala.size shouldBe 3
 
-       simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
 
       //not retain key or headers
       combinedRecord.keySchema() shouldBe null
@@ -346,15 +395,27 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       val originalRecord = sinkRecordWithKeyHeaders()
 
       val combinedRecord = originalRecord.newFilteredRecord(
-        fields = createSchema.fields().asScala.map(f => (f.name(), f.name())).toMap,
+        fields =
+          createSchema.fields().asScala.map(f => (f.name(), f.name())).toMap,
         ignoreFields = Set.empty[String],
         keyFields = Map.empty,
         headerFields = Map.empty
       )
 
-      combinedRecord.valueSchema().fields().asScala.count(_.name().equals("key_int_field")) shouldBe 0
-      combinedRecord.valueSchema().fields().asScala.count(_.name().equals("header_alias_field_3")) shouldBe 0
-      combinedRecord.valueSchema().fields().asScala.size shouldBe originalRecord.valueSchema().fields().size
+      combinedRecord
+        .valueSchema()
+        .fields()
+        .asScala
+        .count(_.name().equals("key_int_field")) shouldBe 0
+      combinedRecord
+        .valueSchema()
+        .fields()
+        .asScala
+        .count(_.name().equals("header_alias_field_3")) shouldBe 0
+      combinedRecord.valueSchema().fields().asScala.size shouldBe originalRecord
+        .valueSchema()
+        .fields()
+        .size
     }
 
     "select * from value fields for struct" in {
@@ -367,9 +428,16 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         headerFields = Map.empty
       )
 
-      combinedRecord.valueSchema().fields().asScala.size shouldBe originalRecord.valueSchema().fields().size
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe(
-        simpleJsonConverter.fromConnectData(originalRecord.valueSchema(), originalRecord.value()).toString
+      combinedRecord.valueSchema().fields().asScala.size shouldBe originalRecord
+        .valueSchema()
+        .fields()
+        .size
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe (
+        simpleJsonConverter
+          .fromConnectData(originalRecord.valueSchema(), originalRecord.value())
+          .toString
       )
     }
 
@@ -383,10 +451,17 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         headerFields = Map.empty
       )
 
-      combinedRecord.valueSchema().fields().asScala.size shouldBe originalRecord.valueSchema().fields().size
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe(
-        simpleJsonConverter.fromConnectData(originalRecord.keySchema(), originalRecord.key()).toString
-        )
+      combinedRecord.valueSchema().fields().asScala.size shouldBe originalRecord
+        .valueSchema()
+        .fields()
+        .size
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe (
+        simpleJsonConverter
+          .fromConnectData(originalRecord.keySchema(), originalRecord.key())
+          .toString
+      )
     }
 
     "select * from headers fields for struct" in {
@@ -399,9 +474,14 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         headerFields = Map("*" -> "*")
       )
 
-      val expected = "{\"header_field_1\":\"foo\",\"header_field_2\":\"bar\",\"header_field_3\":\"boo\"}"
-      combinedRecord.valueSchema().fields().asScala.size shouldBe originalRecord.headers().size
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      val expected =
+        "{\"header_field_1\":\"foo\",\"header_field_2\":\"bar\",\"header_field_3\":\"boo\"}"
+      combinedRecord.valueSchema().fields().asScala.size shouldBe originalRecord
+        .headers()
+        .size
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
 
     "select some fields from headers for struct" in {
@@ -416,7 +496,9 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
 
       val expected = "{\"my_header_alias\":\"foo\"}"
       combinedRecord.valueSchema().fields().asScala.size shouldBe 1
-       simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
 
     "should return empty record for struct" in {
@@ -461,8 +543,11 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         retainHeaders = true
       )
 
-      val expected = "{\"id\":\"sink_test-1-1\",\"long_field\":1,\"string_field\":\"foo\"}"
-       simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      val expected =
+        "{\"id\":\"sink_test-1-1\",\"long_field\":1,\"string_field\":\"foo\"}"
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
 
     "should add fields, key fields and headers for schemaless JSON" in {
@@ -486,10 +571,15 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       headers.addFloat("header_float", 1.1f)
       headers.addDecimal("header_decimal", new java.math.BigDecimal("2.1"))
 
-      val record = new SinkRecord("t", 0, null, keys, null, fields, 0, null, null, headers)
+      val record =
+        new SinkRecord("t", 0, null, keys, null, fields, 0, null, null, headers)
 
       val combinedRecord = record.newFilteredRecord(
-        fields = Map("field2" -> "field2_alias", "field3" -> "field3", "field4" -> "field4", "field5" -> "field5", "field6" -> "field6"),
+        fields = Map("field2" -> "field2_alias",
+                     "field3" -> "field3",
+                     "field4" -> "field4",
+                     "field5" -> "field5",
+                     "field6" -> "field6"),
         ignoreFields = Set.empty,
         keyFields = Map("key_field1" -> "key_field1_alias"),
         headerFields = Map("*" -> "*"),
@@ -497,8 +587,11 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         retainHeaders = true
       )
 
-      val expected = "{\"key_field1_alias\":\"key_value1\",\"field5\":1.1,\"field4\":true,\"field3\":null,\"field2_alias\":3,\"field6\":[1,2,3],\"header_boolean\":true,\"header_int\":1,\"header_string\":\"header_string_value\",\"header_float\":1.1,\"header_decimal\":2.1}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      val expected =
+        "{\"key_field1_alias\":\"key_value1\",\"field5\":1.1,\"field4\":true,\"field3\":null,\"field2_alias\":3,\"field6\":[1,2,3],\"header_boolean\":true,\"header_int\":1,\"header_string\":\"header_string_value\",\"header_float\":1.1,\"header_decimal\":2.1}"
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
 
     "should add fields, key fields and headers for JSON with string schema" in {
@@ -521,7 +614,13 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
           |}
         """.stripMargin
 
-      val record = new SinkRecord("t", 0, Schema.STRING_SCHEMA, keyJson, Schema.STRING_SCHEMA, json, 0)
+      val record = new SinkRecord("t",
+                                  0,
+                                  Schema.STRING_SCHEMA,
+                                  keyJson,
+                                  Schema.STRING_SCHEMA,
+                                  json,
+                                  0)
 
       val combinedRecord = record.newFilteredRecord(
         fields = Map("field1" -> "field1_alias"),
@@ -532,8 +631,11 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
         retainHeaders = true
       )
 
-      val expected = "{\"key_field1_alias\":\"value1\",\"field1_alias\":\"value1\"}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      val expected =
+        "{\"key_field1_alias\":\"value1\",\"field1_alias\":\"value1\"}"
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
 
     "should return empty value" in {
@@ -556,7 +658,13 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
           |}
         """.stripMargin
 
-      val record = new SinkRecord("t", 0, Schema.STRING_SCHEMA, keyJson, Schema.STRING_SCHEMA, json, 0)
+      val record = new SinkRecord("t",
+                                  0,
+                                  Schema.STRING_SCHEMA,
+                                  keyJson,
+                                  Schema.STRING_SCHEMA,
+                                  json,
+                                  0)
 
       val combinedRecord = record.newFilteredRecord(
         fields = Map.empty,
@@ -568,7 +676,9 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       )
 
       val expected = "{}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
 
     "should convert key with no headers, no value" in {
@@ -581,7 +691,8 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
           |   "key_field3":""
           |}
         """.stripMargin
-      val record = new SinkRecord("t", 0, Schema.STRING_SCHEMA, keyJson, null, null, 0)
+      val record =
+        new SinkRecord("t", 0, Schema.STRING_SCHEMA, keyJson, null, null, 0)
 
       val combinedRecord = record.newFilteredRecord(
         fields = Map.empty,
@@ -593,7 +704,9 @@ class TestConverterUtil extends TestUtilsBase with ConverterUtil {
       )
 
       val expected = "{\"key_field1_alias\":\"value1\"}"
-      simpleJsonConverter.fromConnectData(combinedRecord.valueSchema(), combinedRecord.value()).toString shouldBe expected
+      simpleJsonConverter
+        .fromConnectData(combinedRecord.valueSchema(), combinedRecord.value())
+        .toString shouldBe expected
     }
   }
 }


### PR DESCRIPTION
Create a new sinkrecords (value) with struct schema from an existing sinkrecord:

- Include optional fields from the key (json with schema, json without, struct)
- Include optional fields from the value (json with schema, json without, struct)
- Include optional fields from the header - added as string field to value
- retain headers and key

Json payload types as string field in the new struct for now.
